### PR TITLE
Fix "<import> used before it was defined"

### DIFF
--- a/eslint-config-base/index.js
+++ b/eslint-config-base/index.js
@@ -125,7 +125,7 @@ module.exports = {
     "@typescript-eslint/camelcase": ["off"],
 
     // Use typescript's definition checker
-    "no-use-before-define": [0],
-    "@typescript-eslint/no-use-before-define": [1],
+    "no-use-before-define": ["off"],
+    "@typescript-eslint/no-use-before-define": ["warn"],
   },
 }

--- a/eslint-config-base/index.js
+++ b/eslint-config-base/index.js
@@ -123,5 +123,9 @@ module.exports = {
     // We allow underscores in some situations, such as internal_ or unstable_. Additionally,
     // many of the libraries we use commonly use underscores, so disable this rule.
     "@typescript-eslint/camelcase": ["off"],
+
+    // Use typescript's definition checker
+    "no-use-before-define": [0],
+    "@typescript-eslint/no-use-before-define": [1],
   },
 }

--- a/eslint-config-base/index.js
+++ b/eslint-config-base/index.js
@@ -127,5 +127,10 @@ module.exports = {
     // Use typescript's definition checker
     "no-use-before-define": ["off"],
     "@typescript-eslint/no-use-before-define": ["warn"],
+    
+    "prettier/prettier": [
+      "error",
+      { endOfLine: "auto" },
+    ],
   },
 }

--- a/eslint-config-base/package.json
+++ b/eslint-config-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/eslint-config-base",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Shared eslint config for Javascript at @inrupt",
   "main": "index.js",
   "scripts": {

--- a/eslint-config-lib/package.json
+++ b/eslint-config-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/eslint-config-lib",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Shared eslint config for Javascript at @inrupt",
   "main": "index.js",
   "scripts": {
@@ -22,6 +22,6 @@
   "homepage": "https://github.com/inrupt/javascript-style-configs#readme",
   "peerDependencies": {
     "eslint": "^7.1.0",
-    "@inrupt/eslint-config-base": "^0.1.0"
+    "@inrupt/eslint-config-base": "^0.1.1"
   }
 }

--- a/eslint-config-react-ts/package.json
+++ b/eslint-config-react-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/eslint-config-react-ts",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Shared eslint config for Javascript at @inrupt",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/inrupt/javascript-style-configs#readme",
   "peerDependencies": {
-    "@inrupt/eslint-config-base": "^0.1.0",
+    "@inrupt/eslint-config-base": "^0.1.1",
     "@inrupt/eslint-config-react": "^0.1.0",
     "eslint": "^7.1.0",
     "eslint-config-airbnb": "^18.1.0",

--- a/eslint-config-react/index.js
+++ b/eslint-config-react/index.js
@@ -72,6 +72,8 @@ module.exports = {
     }],
 
     "license-header/header": ["warn", "./resources/license-header.js"],
+
+    "no-use-before-define": [1],
   },
 
   overrides: [{
@@ -81,6 +83,10 @@ module.exports = {
       "@typescript-eslint/ban-ts-comment": "off",
       "license-header/header": ["warn", "./resources/license-header.js"],
       "react/jsx-filename-extension": ["warn", { extensions: [".tsx", ".jsx"] }],
+
+      // Switch to typescript's definition checker for ts files
+      "no-use-before-define": [0],
+      "@typescript-eslint/no-use-before-define": [1],
     },
     settings: {
       "import/resolver": {

--- a/eslint-config-react/index.js
+++ b/eslint-config-react/index.js
@@ -73,7 +73,7 @@ module.exports = {
 
     "license-header/header": ["warn", "./resources/license-header.js"],
 
-    "no-use-before-define": [1],
+    "no-use-before-define": ["warn"],
   },
 
   overrides: [{

--- a/eslint-config-react/index.js
+++ b/eslint-config-react/index.js
@@ -85,8 +85,8 @@ module.exports = {
       "react/jsx-filename-extension": ["warn", { extensions: [".tsx", ".jsx"] }],
 
       // Switch to typescript's definition checker for ts files
-      "no-use-before-define": [0],
-      "@typescript-eslint/no-use-before-define": [1],
+      "no-use-before-define": ["off"],
+      "@typescript-eslint/no-use-before-define": ["warn"],
     },
     settings: {
       "import/resolver": {

--- a/eslint-config-react/package.json
+++ b/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/eslint-config-react",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Shared eslint config for Javascript at @inrupt",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/inrupt/javascript-style-configs#readme",
   "peerDependencies": {
-    "@inrupt/eslint-config-base": "^0.1.0",
+    "@inrupt/eslint-config-base": "^0.1.1",
     "eslint": "^7.1.0",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",


### PR DESCRIPTION
Current iterations of typescript+eslint fail to recognize imports properly. Prefer typescript's implementation. See more here:

https://github.com/typescript-eslint/typescript-eslint/issues/2502#issuecomment-689595020