### PR TITLE
Remove prettier/@typescript-eslint from config

### DIFF
--- a/eslint-config-lib/index.js
+++ b/eslint-config-lib/index.js
@@ -22,8 +22,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 module.exports = {
   extends: [
     "@inrupt/eslint-config-base",
-    "plugin:@typescript-eslint/recommended",
-    "prettier/@typescript-eslint"
+    "plugin:@typescript-eslint/recommended"
   ],
 
   plugins: [


### PR DESCRIPTION
"prettier/@typescript-eslint" has been merged into "prettier" in eslint-config-prettier 8.0.0. See: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21