### PR TITLE
Allow any tsconfig in a project to be picked up for ts linting

### DIFF
--- a/eslint-config-lib/index.js
+++ b/eslint-config-lib/index.js
@@ -29,31 +29,37 @@ module.exports = {
     "@typescript-eslint"
   ],
 
-  parser: "@typescript-eslint/parser",
+  overrides: [
+    {
+      files: [ "*.ts", "*.tsx" ],
 
-  // Load typescript rules to handle es6 and typescript
-  parserOptions: {
-    project: "./tsconfig.json",
-    ecmaVersion: 2018,
-    sourceType: "module",
-  },
+      parser: "@typescript-eslint/parser",
 
-  rules: {
-    "@typescript-eslint/return-await": ["error", "in-try-catch"],
+      // Load typescript rules to handle es6 and typescript
+      parserOptions: {
+        project: "./**/tsconfig*.json",
+        ecmaVersion: 2018,
+        sourceType: "module",
+      },
 
-    // Allow empty arrow functions, useful as defaults or for testing mocks
-    "@typescript-eslint/no-empty-function": [
-      "error", { "allow": ["arrowFunctions"] }
-    ],
+      rules: {
+        "@typescript-eslint/return-await": ["error", "in-try-catch"],
 
-    "@typescript-eslint/no-floating-promises": "error",
+        // Allow empty arrow functions, useful as defaults or for testing mocks
+        "@typescript-eslint/no-empty-function": [
+          "error", { "allow": ["arrowFunctions"] }
+        ],
 
-    // We allow underscores in some situations, such as internal_ or unstable_. Additionally,
-    // many of the libraries we use commonly use underscores, so disable this rule.
-    "@typescript-eslint/camelcase": ["off"],
+        "@typescript-eslint/no-floating-promises": "error",
 
-    // Use typescript's definition checker
-    "no-use-before-define": ["off"],
-    "@typescript-eslint/no-use-before-define": ["warn"],
-  },
+        // We allow underscores in some situations, such as internal_ or unstable_. Additionally,
+        // many of the libraries we use commonly use underscores, so disable this rule.
+        "@typescript-eslint/camelcase": ["off"],
+
+        // Use typescript's definition checker
+        "no-use-before-define": ["off"],
+        "@typescript-eslint/no-use-before-define": ["warn"],
+      },
+    },
+  ],
 }


### PR DESCRIPTION
This would allow any tsconfig file in a project to be picked up, hence simplifying our eslint configuration in many projects.

The files that just need to be picked up by the linter are not the same files that need to be built.

Usually, all you need is a tsconfig at the root of a test/e2e or project picking up for example all in the directory or all the .test.ts files.

Starting with that, we can probably simplify quite a bit of our config. See for example https://github.com/inrupt/solid-client-authn-js/pull/1949/files#diff-41a731c40e4a4f9a01a0404d5ad788ac39901f0358424c257e74896f22390a3c